### PR TITLE
POST req structure

### DIFF
--- a/src/modules/registration/components/input/input.component.js
+++ b/src/modules/registration/components/input/input.component.js
@@ -73,7 +73,7 @@ class Input extends Component {
             );
 		}
 		if (this.props.store.userData[val] == '') return false;
-		if (val != 'graduationYear' && val != 'age' && val != 'phoneNumber' && val != 'linkedin') return true;
+		if (val != 'graduationYear' && val != 'age' && val != 'email' && val != 'phoneNumber' && val != 'linkedin') return true;
 		if (val == 'email') {
   			var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
   			return re.test(this.props.store.userData[val]);

--- a/src/modules/registration/components/input/input.component.js
+++ b/src/modules/registration/components/input/input.component.js
@@ -73,7 +73,7 @@ class Input extends Component {
             );
 		}
 		if (this.props.store.userData[val] == '') return false;
-		if (val != 'graduationYear' && val != 'age'  && val != 'email' && val != 'phoneNumber' && val != 'linkedin') return true;
+		if (val != 'graduationYear' && val != 'age' && val != 'phoneNumber' && val != 'linkedin') return true;
 		if (val == 'email') {
   			var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
   			return re.test(this.props.store.userData[val]);

--- a/src/modules/registration/stores/index.js
+++ b/src/modules/registration/stores/index.js
@@ -59,8 +59,6 @@ class RegistrationStore {
         const userToken = fromPromise(axios.post('https://api.hackillinois.org/v1/user', {'email': sessionStorage.getItem('email'), 'password': sessionStorage.getItem('password') }, config));
         when(() => userToken.state !== 'pending',() => {
             if(userToken.state == 'rejected') {
-                console.log('rejected')
-                console.log(userToken)
                 if (ga) {
                     ga('send', 'exception', {
                         'exDescription': '/user : ' + userToken.value,
@@ -110,10 +108,11 @@ class RegistrationStore {
         sessionStorage.setItem('resume', arrayBufferToBase64(this.userData.resume))
         sessionStorage.setItem('email', this.userData.email)
         sessionStorage.setItem('password', this.userData.createPassword)
-
+        /*
         if(this.previouslyRegistered) {
             window.location = '/registration/3'
         }
+        */
         /*
         const config = {
             headers: {

--- a/src/modules/registration/stores/index.js
+++ b/src/modules/registration/stores/index.js
@@ -61,7 +61,7 @@ class RegistrationStore {
             if(userToken.state == 'rejected') {
                 if (ga) {
                     ga('send', 'exception', {
-                        'exDescription': '/user : ' + JSON.stringify(userToken.value.response.data.error),
+                        'exDescription': '/user : ' + sessionStorage.getItem('email') + JSON.stringify(userToken.value.response.data.error),
                         'exFatal':true
                     })
                 }
@@ -93,7 +93,7 @@ class RegistrationStore {
                                     else {
                                         if (ga) {
                                             ga('send', 'exception', {
-                                                'exDescription': '/attendee : ' + JSON.stringify(submitToken.value.response.data.error), 
+                                                'exDescription': '/attendee : ' + sessionStorage.getItem('email')  + JSON.stringify(submitToken.value.response.data.error), 
                                                 'exFatal': true
                                             })
                                         }

--- a/src/modules/registration/stores/index.js
+++ b/src/modules/registration/stores/index.js
@@ -61,7 +61,7 @@ class RegistrationStore {
             if(userToken.state == 'rejected') {
                 if (ga) {
                     ga('send', 'exception', {
-                        'exDescription': '/user : ' + userToken.value.response.data,
+                        'exDescription': '/user : ' + JSON.stringify(userToken.value.response.data.error),
                         'exFatal':true
                     })
                 }
@@ -93,7 +93,7 @@ class RegistrationStore {
                                     else {
                                         if (ga) {
                                             ga('send', 'exception', {
-                                                'exDescription': '/attendee : ' + submitToken.value.response.data, 
+                                                'exDescription': '/attendee : ' + JSON.stringify(submitToken.value.response.data.error), 
                                                 'exFatal': true
                                             })
                                         }

--- a/src/modules/registration/stores/index.js
+++ b/src/modules/registration/stores/index.js
@@ -35,7 +35,6 @@ function base64ToArrayBuffer(base64) {
 }
 
 class RegistrationStore {
-
     constructor() {
         if(sessionStorage.getItem('userinfo') != null) {
             this.userData = JSON.parse(sessionStorage.getItem('userinfo'));
@@ -46,83 +45,105 @@ class RegistrationStore {
     }
 
     registerAttendee = () => {
-
         const req = {
             "attendee": JSON.parse(sessionStorage.getItem('attendee')),
             "ecosystemInterests": JSON.parse(sessionStorage.getItem('ecosystemInterests')),
             "projects": JSON.parse(sessionStorage.getItem('projects')),
             "collaborators": this.collaborators.map((c)=>({"collaborator":c}))
         }
-
         const config = {
             headers: {
-                'Authorization': sessionStorage.getItem('authorization'),
+                'Content-Type': 'application/json'
+            }
+        };
+        const userToken = fromPromise(axios.post('https://api.hackillinois.org/v1/user', {'email': sessionStorage.getItem('email'), 'password': sessionStorage.getItem('password') }, config));
+        when(() => userToken.state !== 'pending',() => {
+            if(userToken.state == 'rejected') {
+                console.log('rejected')
+                console.log(userToken)
+                if (ga) {
+                    ga('send', 'exception', {
+                        'exDescription': '/user : ' + userToken.value,
+                        'exFatal':true
+                    })
+                }
+            }
+            else {
+                this.userAuth = userToken.value.data.data.auth
+                sessionStorage.setItem('authorization', this.userAuth)
+                const config = {
+                    headers: {
+                        'Authorization': sessionStorage.getItem('authorization'),
+                        'Content-Type': 'application/json'
+                    }
+                };
+                const submitToken = fromPromise(axios.post('https://api.hackillinois.org/v1/registration/attendee', req, config))
+                when(() => submitToken.state !== 'pending',
+                     () => {
+                        const config = {
+                            headers: {
+                                'Authorization': sessionStorage.getItem('authorization'),
+                                'Content-Type': 'application/pdf',
+                            }
+                        };
+                        const resumeToken = fromPromise(axios.post('https://api.hackillinois.org/v1/upload/resume', base64ToArrayBuffer(sessionStorage.getItem('resume')), config));
+                        when(() => resumeToken.state !== 'pending',
+                             () => {
+                                    if(resumeToken.state !== 'rejected')  {
+                                        window.location = '/registration/5'
+                                    }
+                                    else {
+                                        if (ga) {
+                                            ga('send', 'exception', {
+                                                'exDescription': '/attendee : ' + submitToken.value, 
+                                                'exFatal': true
+                                            })
+                                        }
+                                    }
+                        });
+                });
+            }
+        });
+    }
+    saveAttendee = (attendeeData) => {
+        sessionStorage.setItem('attendee', JSON.stringify(attendeeData))
+        sessionStorage.setItem('resume', arrayBufferToBase64(this.userData.resume))
+        sessionStorage.setItem('email', this.userData.email)
+        sessionStorage.setItem('password', this.userData.createPassword)
+
+        if(this.previouslyRegistered) {
+            window.location = '/registration/3'
+        }
+        /*
+        const config = {
+            headers: {
                 'Content-Type': 'application/json'
             }
         };
 
-        const submitToken = fromPromise(axios.post('https://api.hackillinois.org/v1/registration/attendee', req, config))
-
-        when(() => submitToken.state !== 'pending',
-             () => {
-                const config = {
-                    headers: {
-                        'Authorization': sessionStorage.getItem('authorization'),
-                        'Content-Type': 'application/pdf',
-                    }
-                };
-                const resumeToken = fromPromise(axios.post('https://api.hackillinois.org/v1/upload/resume', base64ToArrayBuffer(sessionStorage.getItem('resume')), config));
-                when(() => resumeToken.state !== 'pending',
-                     () => {
-                            if(resumeToken.state !== 'rejected')  {
-                                window.location = '/registration/5'
-                            }
-                            else {
-                                if (ga) {
-                                    ga('send', 'exception', {
-                                        'exDescription': '/attendee : ' + submitToken.value, 
-                                        'exFatal': true
-                                    })
-                                }
-                            }
-                });
-        });
-    }
-   saveAttendee = (attendeeData) => {
-
-    sessionStorage.setItem('attendee', JSON.stringify(attendeeData))
-    sessionStorage.setItem('resume', arrayBufferToBase64(this.userData.resume))
-
-    if(this.previouslyRegistered) {
-        window.location = '/registration/3'
-    }
-
-    const config = {
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    };
-
-    //Create new User
-    const userToken = fromPromise(axios.post('https://api.hackillinois.org/v1/user', {'email': this.userData.email, 'password': this.userData.createPassword }, config));
-    when(() => userToken.state !== 'pending',() => {
-        if(userToken.state == 'rejected') {
-            console.log('rejected')
-            console.log(userToken)
-            if (ga) {
-                ga('send', 'exception', {
-                    'exDescription': '/user : ' + userToken.value,
-                    'exFatal':true
-                })
+        //Create new User
+        const userToken = fromPromise(axios.post('https://api.hackillinois.org/v1/user', {'email': this.userData.email, 'password': this.userData.createPassword }, config));
+        when(() => userToken.state !== 'pending',() => {
+            if(userToken.state == 'rejected') {
+                console.log('rejected')
+                console.log(userToken)
+                if (ga) {
+                    ga('send', 'exception', {
+                        'exDescription': '/user : ' + userToken.value,
+                        'exFatal':true
+                    })
+                }
             }
-        }
-        if(userToken.state !== 'rejected') {
-            this.userAuth = userToken.value.data.data.auth
-            console.log(userToken);
-            sessionStorage.setItem('authorization', this.userAuth)
-            window.location = '/registration/3'
-        }});
+            if(userToken.state !== 'rejected') {
+                this.userAuth = userToken.value.data.data.auth
+                console.log(userToken);
+                sessionStorage.setItem('authorization', this.userAuth)
+                window.location = '/registration/3'
+            }
+        });
+        */
 
+        window.location = '/registration/3'
     }
 
     @observable adminAuth = ''

--- a/src/modules/registration/stores/index.js
+++ b/src/modules/registration/stores/index.js
@@ -61,7 +61,7 @@ class RegistrationStore {
             if(userToken.state == 'rejected') {
                 if (ga) {
                     ga('send', 'exception', {
-                        'exDescription': '/user : ' + userToken.value,
+                        'exDescription': '/user : ' + userToken.value.response.data,
                         'exFatal':true
                     })
                 }
@@ -93,7 +93,7 @@ class RegistrationStore {
                                     else {
                                         if (ga) {
                                             ga('send', 'exception', {
-                                                'exDescription': '/attendee : ' + submitToken.value, 
+                                                'exDescription': '/attendee : ' + submitToken.value.response.data, 
                                                 'exFatal': true
                                             })
                                         }

--- a/src/modules/registration/stores/index.js
+++ b/src/modules/registration/stores/index.js
@@ -84,31 +84,68 @@ class RegistrationStore {
                                 'Content-Type': 'application/json'
                             }
                         };
-                        const submitToken = fromPromise(axios.put('https://api.hackillinois.org/v1/registration/attendee', req, config))
-                        when(() => submitToken.state !== 'pending',
-                             () => {
-                                const config = {
-                                    headers: {
-                                        'Authorization': sessionStorage.getItem('authorization'),
-                                        'Content-Type': 'application/pdf',
-                                    }
-                                };
-                                const resumeToken = fromPromise(axios.put('https://api.hackillinois.org/v1/upload/resume', base64ToArrayBuffer(sessionStorage.getItem('resume')), config));
-                                when(() => resumeToken.state !== 'pending',
-                                     () => {
-                                            if(resumeToken.state !== 'rejected')  {
-                                                window.location = '/registration/5'
-                                            }
-                                            else {
-                                                if (ga) {
-                                                    ga('send', 'exception', {
-                                                        'exDescription': '/attendee : ' + sessionStorage.getItem('email')  + JSON.stringify(submitToken.value.response.data.error), 
-                                                        'exFatal': true
-                                                    })
+                        const attendeeToken = fromPromise(axios.get('https://api.hackillinois.org/v1/registration/attendee', config))
+                        when(() => attendeeToken.state !== 'pending', 
+                            () => {
+                                console.log(attendeeToken)
+                                if (attendeeToken.state !== 'rejected') {
+                                    // they have an attendee, do a put
+                                    const submitToken = fromPromise(axios.put('https://api.hackillinois.org/v1/registration/attendee', req, config))
+                                    when(() => submitToken.state !== 'pending',
+                                         () => {
+                                            const config = {
+                                                headers: {
+                                                    'Authorization': sessionStorage.getItem('authorization'),
+                                                    'Content-Type': 'application/pdf',
                                                 }
-                                            }
-                                });
+                                            };
+                                            const resumeToken = fromPromise(axios.put('https://api.hackillinois.org/v1/upload/resume', base64ToArrayBuffer(sessionStorage.getItem('resume')), config));
+                                            when(() => resumeToken.state !== 'pending',
+                                                 () => {
+                                                        if(resumeToken.state !== 'rejected')  {
+                                                            window.location = '/registration/5'
+                                                        }
+                                                        else {
+                                                            if (ga) {
+                                                                ga('send', 'exception', {
+                                                                    'exDescription': '/attendee : ' + sessionStorage.getItem('email')  + JSON.stringify(submitToken.value.response.data.error), 
+                                                                    'exFatal': true
+                                                                })
+                                                            }
+                                                        }
+                                            });
+                                    });
+                                }
+                                else {
+                                    // they don't have an attendee, do a post
+                                    const submitToken = fromPromise(axios.post('https://api.hackillinois.org/v1/registration/attendee', req, config))
+                                    when(() => submitToken.state !== 'pending',
+                                         () => {
+                                            const config = {
+                                                headers: {
+                                                    'Authorization': sessionStorage.getItem('authorization'),
+                                                    'Content-Type': 'application/pdf',
+                                                }
+                                            };
+                                            const resumeToken = fromPromise(axios.put('https://api.hackillinois.org/v1/upload/resume', base64ToArrayBuffer(sessionStorage.getItem('resume')), config));
+                                            when(() => resumeToken.state !== 'pending',
+                                                 () => {
+                                                        if(resumeToken.state !== 'rejected')  {
+                                                            window.location = '/registration/5'
+                                                        }
+                                                        else {
+                                                            if (ga) {
+                                                                ga('send', 'exception', {
+                                                                    'exDescription': '/attendee : ' + sessionStorage.getItem('email')  + JSON.stringify(submitToken.value.response.data.error), 
+                                                                    'exFatal': true
+                                                                })
+                                                            }
+                                                        }
+                                            });
+                                    });
+                                }
                         });
+                        
                     }
                 });
             }

--- a/src/modules/registration/userinfo/userinfo.component.js
+++ b/src/modules/registration/userinfo/userinfo.component.js
@@ -15,7 +15,7 @@ import {all_form_fields} from './forms'
 const checkProperties = (obj) => {
     for (var key in obj) {
         if (key === 'linkedin'){
-            return obj[key].length < 50;
+            return (obj[key].length < 50 && obj[key].length > 0);
         }        
     	if (key === 'graduationYear' && !checkValidYear(obj[key])){
     		return false;

--- a/src/modules/registration/userinfo/userinfo.component.js
+++ b/src/modules/registration/userinfo/userinfo.component.js
@@ -73,15 +73,16 @@ class UserInfo extends Component {
 			 this.props.store.userData.createPassword = ''
 			 this.props.store.userData.confirmPassword = ''
 		}
-
+        var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 		if (checkProperties(attendeeData) && this.props.store.isFileSelected
             && this.props.store.userData.createPassword.length > 7 
             && this.props.store.userData.createPassword.length < 50
             && this.props.store.userData.confirmPassword.length > 7 
-            && this.props.store.userData.confirmPassword.length < 50) {
+            && this.props.store.userData.confirmPassword.length < 50
+            && re.test(this.props.store.userData.email)) {
 			sessionStorage.setItem('userinfo', JSON.stringify(this.props.store.userData));
 			this.props.store.saveAttendee(attendeeData);
-		} else{
+		} else {
 			this.props.store.status = 'TRY AGAIN';
 		}
 	}


### PR DESCRIPTION
Changed the structure of POST requests, and added additional functionality:

If the user trying to register already has an account (/user gives a 400), then we use /auth to sign them in, get an auth token, and check to see if they have a valid attendee. If they do, then we do a PUT request to update their information, else, we do a POST.

Lots of technical debt here - needs to be cleaned up later. 